### PR TITLE
Updated lodash dependency

### DIFF
--- a/package.json
+++ b/package.json
@@ -28,6 +28,6 @@
     "tape": "^3.0.3"
   },
   "dependencies": {
-    "lodash": "^2.4.1"
+    "lodash": "^3.0.0"
   }
 }


### PR DESCRIPTION
Output from `npm test`:

``` console
> toxic@1.0.0 test /Users/thibaultmaekelbergh/Desktop/temp/toxic
> node test.js | tap-spec


  throws an error for non-object
    ✓ threw error on non-object

  does nothing if no mutator provided
    ✓ not mutated

  mutates all keys and values
    ✓ mutated all values

  mutates only the keys
    ✓ mutated

  mutates only the values
    ✓ mutated

  key or value specific mutator overrides mutator
    ✓ mutated keys
    ✓ mutated values

  tests 7
  pass  7


  Pass!
```
