### PR TITLE
Update lodash to ^4.17.10

### DIFF
--- a/index.js
+++ b/index.js
@@ -14,7 +14,6 @@ module.exports = function (data, options) {
   
   return _(data)
     .map(function (value, key) {
-      
       // Which mutator to use
       var keyMutator = options.keyMutator || options.mutator;
       var valueMutator = options.valueMutator || options.mutator;
@@ -25,6 +24,6 @@ module.exports = function (data, options) {
       ];
     })
     .filter(_.identity)
-    .zipObject()
+    .fromPairs()
     .value();
 };

--- a/package.json
+++ b/package.json
@@ -28,6 +28,6 @@
     "tape": "^3.0.3"
   },
   "dependencies": {
-    "lodash": "^3.0.0"
+    "lodash": "^4.17.10"
   }
 }


### PR DESCRIPTION
There's a security advisory on lodash 3.x, which this project is currently using: https://nodesecurity.io/advisories/577

(Actually the latest published version is using lodash@^2.4.1)