### PR TITLE
Update lodash to ^4.17.21 and update tape to ^5.9.0

### DIFF
--- a/package.json
+++ b/package.json
@@ -25,9 +25,9 @@
   "homepage": "https://github.com/scottcorgan/toxic",
   "devDependencies": {
     "tap-spec": "^1.0.1",
-    "tape": "^3.0.3"
+    "tape": "^5.9.0"
   },
   "dependencies": {
-    "lodash": "^4.17.10"
+    "lodash": "^4.17.21"
   }
 }


### PR DESCRIPTION
- Update lodash to ^4.17.21
    - this update is to fix Code Injection and Prototype Pollution vulnerabilities in lodash <= 4.17.17
    - https://security.snyk.io/package/npm/lodash
- Update tape to ^5.9.0